### PR TITLE
fix(RQTCTR-6551): add esquema carta documento

### DIFF
--- a/idl/EventosDeTraza.avdl
+++ b/idl/EventosDeTraza.avdl
@@ -49,17 +49,14 @@ protocol EsquemasProtocol {
     string submotivo;
   }
 
-  @namespace("Integracion.Esquemas.CartasDocumentoImpreso")
   record CartaDocumentoImpreso{
     Integracion.Esquemas.Traza traza;
   }
 
-  @namespace("Integracion.Esquemas.CartasDocumentoPendienteImpresion")
   record CartaDocumentoPendienteImpresion{
     Integracion.Esquemas.Traza traza;
   }
 
-  @namespace("Integracion.Esquemas.CartasDocumentoRechazo")
   record CartaDocumentoRechazo{
     Integracion.Esquemas.Traza traza;
     string motivo;

--- a/idl/EventosDeTraza.avdl
+++ b/idl/EventosDeTraza.avdl
@@ -49,6 +49,23 @@ protocol EsquemasProtocol {
     string submotivo;
   }
 
+  @namespace("Integracion.Esquemas.CartaDocumentoImpreso")
+  record EventoDeRespuesta{
+    Integracion.Esquemas.Traza traza;
+  }
+
+  @namespace("Integracion.Esquemas.CartaDocumentoPendienteImpresion")
+  record EventoDeRespuesta{
+    Integracion.Esquemas.Traza traza;
+  }
+
+  @namespace("Integracion.Esquemas.CartaDocumentoRechazo")
+  record EventoDeRespuesta{
+    Integracion.Esquemas.Traza traza;
+    string motivo;
+    string submotivo;
+  }
+
   record NovedadEnEnvio{
     Integracion.Esquemas.Referencias.DetalleDeEnvio envio;
   }

--- a/idl/EventosDeTraza.avdl
+++ b/idl/EventosDeTraza.avdl
@@ -49,18 +49,18 @@ protocol EsquemasProtocol {
     string submotivo;
   }
 
-  @namespace("Integracion.Esquemas.CartaDocumentoImpreso")
-  record EventoDeRespuesta{
+  @namespace("Integracion.Esquemas.CartasDocumentoImpreso")
+  record CartaDocumentoImpreso{
     Integracion.Esquemas.Traza traza;
   }
 
-  @namespace("Integracion.Esquemas.CartaDocumentoPendienteImpresion")
-  record EventoDeRespuesta{
+  @namespace("Integracion.Esquemas.CartasDocumentoPendienteImpresion")
+  record CartaDocumentoPendienteImpresion{
     Integracion.Esquemas.Traza traza;
   }
 
-  @namespace("Integracion.Esquemas.CartaDocumentoRechazo")
-  record EventoDeRespuesta{
+  @namespace("Integracion.Esquemas.CartasDocumentoRechazo")
+  record CartaDocumentoRechazo{
     Integracion.Esquemas.Traza traza;
     string motivo;
     string submotivo;


### PR DESCRIPTION
This pull request adds new event response record types to the `EsquemasProtocol` Avro interface definition. These records are designed to represent responses related to different document events, each with appropriate fields for traceability and reason details.

**New event response records:**

* Added `EventoDeRespuesta` record under the `Integracion.Esquemas.CartaDocumentoImpreso` namespace, containing a `traza` field for traceability.
* Added `EventoDeRespuesta` record under the `Integracion.Esquemas.CartaDocumentoPendienteImpresion` namespace, also with a `traza` field.
* Added `EventoDeRespuesta` record under the `Integracion.Esquemas.CartaDocumentoRechazo` namespace, including `traza`, `motivo`, and `submotivo` fields to capture rejection reasons.